### PR TITLE
Export all types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,17 +2,14 @@ import { hashTreeRoot } from "./hashTreeRoot";
 import { deserialize } from "./deserialize";
 import { serialize } from "./serialize";
 import { signedRoot } from "./signedRoot";
-import { AnySSZType, Type, SimpleSSZType, SSZType } from "./types";
 import { parseType } from "./util/types";
 
+export * from "./types";
+
 export {
-  AnySSZType,
   deserialize,
   serialize,
   hashTreeRoot,
   signedRoot,
-  SimpleSSZType,
-  SSZType,
-  Type,
   parseType,
 };


### PR DESCRIPTION
It will be useful for any downstream consumers to be able to easily specify any of the types we've created.