### PR TITLE
Relax input/output value types

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -20,7 +20,7 @@ Deserialize, according to the SSZ spec
 -   `data` **[Buffer][9]** 
 -   `type` **AnySSZType** 
 
-Returns **SerializableValue** 
+Returns **any** 
 
 ## hashTreeRoot
 
@@ -28,7 +28,7 @@ Merkleize an SSZ value
 
 ### Parameters
 
--   `value` **SerializableValue** 
+-   `value` **any** 
 -   `type` **AnySSZType** 
 
 Returns **[Buffer][9]** 
@@ -39,7 +39,7 @@ Serialize, according to the SSZ spec
 
 ### Parameters
 
--   `value` **SerializableValue** 
+-   `value` **any** 
 -   `type` **AnySSZType** 
 
 Returns **[Buffer][9]** 
@@ -51,7 +51,7 @@ Used for signing/verifying signed data
 
 ### Parameters
 
--   `value` **SerializableObject** 
+-   `value` **any** 
 -   `type` **AnyContainerType** 
 
 Returns **[Buffer][9]** 

--- a/src/deserialize.ts
+++ b/src/deserialize.ts
@@ -102,9 +102,9 @@ export function _deserialize(data: Buffer, type: FullSSZType, start: number): De
  * @method deserialize
  * @param {Buffer} data
  * @param {AnySSZType} type
- * @returns {SerializableValue}
+ * @returns {any}
  */
-export function deserialize(data: Buffer, type: AnySSZType): SerializableValue {
+export function deserialize(data: Buffer, type: AnySSZType): any {
   const _type = parseType(type);
   return _deserialize(data, _type, 0).value;
 }

--- a/src/hashTreeRoot.ts
+++ b/src/hashTreeRoot.ts
@@ -62,11 +62,11 @@ export function _hashTreeRoot(value: SerializableValue, type: FullSSZType): Buff
 /**
  * Merkleize an SSZ value
  * @method hashTreeRoot
- * @param {SerializableValue} value
+ * @param {any} value
  * @param {AnySSZType} type
  * @returns {Buffer}
  */
-export function hashTreeRoot(value: SerializableValue, type: AnySSZType): Buffer {
+export function hashTreeRoot(value: any, type: AnySSZType): Buffer {
   const _type = parseType(type);
   return _hashTreeRoot(value, _type);
 }

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -90,11 +90,11 @@ export function _serialize(value: SerializableValue, type: FullSSZType, output: 
 /**
  * Serialize, according to the SSZ spec
  * @method serialize
- * @param {SerializableValue} value
+ * @param {any} value
  * @param {AnySSZType} type
  * @returns {Buffer}
  */
-export function serialize(value: SerializableValue, type: AnySSZType): Buffer {
+export function serialize(value: any, type: AnySSZType): Buffer {
   const _type = parseType(type);
   const buf = Buffer.alloc(size(value, _type));
   _serialize(value, _type, buf, 0);

--- a/src/signedRoot.ts
+++ b/src/signedRoot.ts
@@ -18,11 +18,11 @@ import {
  * Merkleize an SSZ object w/o its last field
  * Used for signing/verifying signed data
  * @method signedRoot
- * @param {SerializableObject} value
+ * @param {any} value
  * @param {AnyContainerType} type
  * @returns {Buffer}
  */
-export function signedRoot(value: SerializableObject, type: AnyContainerType): Buffer {
+export function signedRoot(value: any, type: AnyContainerType): Buffer {
   const _type = parseType(type);
   assert(_type.type === Type.container);
   const truncatedType = copyType(type) as ContainerType;

--- a/src/size.ts
+++ b/src/size.ts
@@ -19,7 +19,7 @@ function _sizeByteArray(value: Bytes, type: BytesType): number {
   return length + BYTES_PER_LENGTH_PREFIX;
 }
 
-export function size(value: SerializableValue, type: FullSSZType): number {
+export function size(value: any, type: FullSSZType): number {
   switch (type.type) {
     case Type.uint:
       return type.byteLength;


### PR DESCRIPTION
Instead of requiring `SerializableValue` typed values for input, returning a `SerializableValue` from `deserialize`, require `any`.

This will make it less cumbersome to cast input and output to the right type for consumers.