### PR TITLE
Fix reduce w/ no initial value

### DIFF
--- a/src/size.ts
+++ b/src/size.ts
@@ -36,11 +36,11 @@ export function size(value: any, type: FullSSZType): number {
       assert((value as SerializableArray).length !== undefined, `Invalid array value: ${value}`);
       return (value as SerializableArray)
         .map((v) => size(v, (type as ArrayType).elementType))
-        .reduce((a, b) => a + b) + BYTES_PER_LENGTH_PREFIX;
+        .reduce((a, b) => a + b, 0) + BYTES_PER_LENGTH_PREFIX;
     case Type.container:
       assert(value === Object(value), `Invalid object value: ${value}`);
       return type.fields
         .map(([fieldName, fieldType]) => size((value as SerializableObject)[fieldName], fieldType))
-        .reduce((a, b) => a + b) + BYTES_PER_LENGTH_PREFIX;
+        .reduce((a, b) => a + b, 0) + BYTES_PER_LENGTH_PREFIX;
   }
 }

--- a/src/util/hash.ts
+++ b/src/util/hash.ts
@@ -13,7 +13,7 @@ import { _serialize } from "../serialize";
 
 export function pack (input: SerializableValue[], type: FullSSZType): Buffer[] {
   // Serialize inputs into one long buffer
-  const packedLength = input.map((v) => size(v, type)).reduce((a, b) => a + b);
+  const packedLength = input.map((v) => size(v, type)).reduce((a, b) => a + b, 0);
   const packedBuf = Buffer.alloc(packedLength);
   let index = 0;
   for (const v of input) {

--- a/test/hashTreeRoot.test.ts
+++ b/test/hashTreeRoot.test.ts
@@ -55,6 +55,7 @@ describe("hashTreeRoot", () => {
     {value: {v:3, subV:{v:6}}, type: OuterObject, expected: ""},
     {value: {v: [{b:2,a:1}, {b:4,a:3}]}, type: ArrayObject, expected: ""},
     {value: [{v:3, subV:{v:6}}, {v:5, subV:{v:7}}], type: [OuterObject], expected: ""},
+    {value: [], type: [OuterObject], expected: ""},
   ];
   for (const {value, type, expected} of testCases) {
     it(`should correctly hash ${stringifyType(type)}`, () => {

--- a/test/serialize.test.ts
+++ b/test/serialize.test.ts
@@ -56,6 +56,7 @@ describe("serialize", () => {
     {value: {v:3, subV:{v:6}}, type: OuterObject, expected: "0700000003020000000600"},
     {value: {v: [{b:2,a:1}, {b:4,a:3}]}, type: ArrayObject, expected: "120000000e0000000300000002000103000000040003"},
     {value: [{v:3, subV:{v:6}}, {v:5, subV:{v:7}}], type: [OuterObject], expected: "1600000007000000030200000006000700000005020000000700"},
+    {value: [], type: [OuterObject], expected: "00000000"},
   ];
   for (const {value, type, expected} of testCases) {
     it(`should correctly serialize ${stringifyType(type)}`, () => {


### PR DESCRIPTION
Lurking bug, if an empty array is passed in (which is definitely going to happen), reduce throws an error if there's no initial value.

Added regression tests to confirm the bug and fix.