### PR TITLE
Allow uint offsets to be specified as BN

### DIFF
--- a/src/deserialize.ts
+++ b/src/deserialize.ts
@@ -8,7 +8,6 @@ import {
   FullSSZType,
   SerializableArray,
   SerializableObject,
-  SerializableValue,
   Type,
   UintType,
 } from "./types";
@@ -19,7 +18,7 @@ import { parseType } from "./util/types";
 
 function _deserializeUint(data: Buffer, type: UintType, start: number): DeserializedValue {
   const offset = start + type.byteLength;
-  const bn = (new BN(data.slice(start, offset), 16, "le")).subn(type.offset);
+  const bn = (new BN(data.slice(start, offset), 16, "le")).sub(new BN(type.offset));
   const value = (type.useNumber || type.byteLength <= 4) ? bn.toNumber() : bn;
   return {
     offset,

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -25,7 +25,7 @@ import { parseType } from "./util/types";
 
 function _serializeUint(value: Uint, type: UintType, output: Buffer, start: number): number {
   const offset = start + type.byteLength;
-  (new BN(value)).addn(type.offset).toArrayLike(Buffer, "le", type.byteLength)
+  (new BN(value)).add(new BN(type.offset)).toArrayLike(Buffer, "le", type.byteLength)
     .copy(output, start);
   return offset;
 }

--- a/src/signedRoot.ts
+++ b/src/signedRoot.ts
@@ -3,7 +3,6 @@ import assert from "assert";
 import {
   AnyContainerType,
   ContainerType,
-  SerializableObject,
   Type,
 } from "./types";
 

--- a/src/size.ts
+++ b/src/size.ts
@@ -7,7 +7,6 @@ import {
   FullSSZType,
   SerializableArray,
   SerializableObject,
-  SerializableValue,
   Type,
 } from "./types";
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -54,7 +54,7 @@ export enum Type {
 export interface UintType {
   type: Type.uint;
   byteLength: number;
-  offset: number;
+  offset: number | BN;
   useNumber: boolean;
 }
 

--- a/test/deserialize.test.ts
+++ b/test/deserialize.test.ts
@@ -4,6 +4,7 @@ import BN from "bn.js";
 
 import {
   SerializableValue,
+  Type,
 } from "../src/types";
 
 import { deserialize } from "../src/deserialize";
@@ -35,6 +36,8 @@ describe("deserialize", () => {
     {value: "ffffff0f", type: "uint32", expected: 2**28-1},
     {value: "00000010", type: "uint32", expected: 2**28},
     {value: "ffffffff", type: "uint32", expected: 2**32-1},
+    {value: "0100000001000000", type: {type: Type.uint, byteLength: 8, offset: 2**32, useNumber: true}, expected: 1},
+    {value: "0100000001000000", type: {type: Type.uint, byteLength: 8, offset: new BN(2**32), useNumber: true}, expected: 1},
     {value: "0000000001000000", type: "uint64", expected: new BN(2**32)},
     {value: "ffffffffffff0f00", type: "uint64", expected: new BN(2**52-1)},
     {value: "0100000000000000", type: "uint64", expected: new BN("01", 16)},

--- a/test/hashTreeRoot.test.ts
+++ b/test/hashTreeRoot.test.ts
@@ -4,6 +4,7 @@ import BN from "bn.js";
 
 import {
   SerializableValue,
+  Type,
 } from "../src/types";
 
 import { hashTreeRoot } from "../src/hashTreeRoot";
@@ -35,6 +36,7 @@ describe("hashTreeRoot", () => {
     {value: 2**28-1, type: "uint32", expected: ""},
     {value: 2**28, type: "uint32", expected: ""},
     {value: 2**32-1, type: "uint32", expected: ""},
+    {value: 1, type: {type: Type.uint, byteLength: 8, offset: 2**32, useNumber: true}, expected: ""},
     {value: 2**32, type: "uint64", expected: ""},
     {value: 2**52-1, type: "uint64", expected: ""},
     {value: 2**32, type: "number64", expected: hashTreeRoot(2**32, "uint64").toString('hex')},

--- a/test/serialize.test.ts
+++ b/test/serialize.test.ts
@@ -4,6 +4,7 @@ import BN from "bn.js";
 
 import {
   SerializableValue,
+  Type,
 } from "../src/types";
 
 import { serialize } from "../src/serialize";
@@ -39,6 +40,8 @@ describe("serialize", () => {
     {value: 2**52-1, type: "uint64", expected: "ffffffffffff0f00"},
     {value: 2**32, type: "number64", expected: "0000000001000000"},
     {value: 2**52-1, type: "number64", expected: "ffffffffffff0f00"},
+    {value: 1, type: {type: Type.uint, byteLength: 8, offset: 2**32, useNumber: true}, expected: "0100000001000000"},
+    {value: 1, type: {type: Type.uint, byteLength: 8, offset: new BN(2**32), useNumber: true}, expected: "0100000001000000"},
     {value: new BN("01", 16), type: "uint64", expected: "0100000000000000"},
     {value: new BN("1000000000000000", 16), type: "uint64", expected: "0000000000000010"},
     {value: new BN("ffffffffffffffff", 16), type: "uint64", expected: "ffffffffffffffff"},


### PR DESCRIPTION
This lets us specify uint offsets in BN as well as number.

Eg:
```typescript
const slotType: UintType = {
  type: Type.uint,
  byteLength: 8,
  offset: new BN(2**32), // <-- this
  useNumber: true,
}
serialize(slot, slotType);
```