### PR TITLE
Include uint Infinity case

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Types are either specified in a simplified form (eg: `"uint32"`) or an extended 
 #### Uint
 A uint serialization value may be either a js `number` or a `BN` from [bn.js](https://github.com/indutny/bn.js).
 A uint type is specified by either `"uintN"` or `"numberN"`, where N is the number of bits to serialize.
-`uintN` > 32 bits is deserialized to a `BN` else deserialized to a `number`.
+`uintN` > 48 bits is deserialized to a `BN` else deserialized to a `number`.
 Every `numberN` is deserialized to a number.
 
 #### Boolean

--- a/src/deserialize.ts
+++ b/src/deserialize.ts
@@ -18,11 +18,19 @@ import { parseType } from "./util/types";
 
 function _deserializeUint(data: Buffer, type: UintType, start: number): DeserializedValue {
   const offset = start + type.byteLength;
-  const bn = (new BN(data.slice(start, offset), 16, "le")).sub(new BN(type.offset));
-  const value = (type.useNumber || type.byteLength <= 4) ? bn.toNumber() : bn;
-  return {
-    offset,
-    value,
+  const uintData = data.slice(start, offset);
+  if (type.byteLength > 6 && type.useNumber && uintData.equals(Buffer.alloc(type.byteLength, 255))) {
+    return {
+      offset,
+      value: Infinity,
+    }
+  } else {
+    const bn = (new BN(uintData, 16, "le")).sub(new BN(type.offset));
+    const value = (type.useNumber || type.byteLength <= 6) ? bn.toNumber() : bn;
+    return {
+      offset,
+      value,
+    }
   }
 }
 

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -25,7 +25,13 @@ import { parseType } from "./util/types";
 
 function _serializeUint(value: Uint, type: UintType, output: Buffer, start: number): number {
   const offset = start + type.byteLength;
-  (new BN(value)).add(new BN(type.offset)).toArrayLike(Buffer, "le", type.byteLength)
+  let bnValue: BN;
+  if (type.byteLength > 6 && type.useNumber && value === Infinity) {
+    bnValue = new BN(Buffer.alloc(type.byteLength, 255));
+  } else {
+    bnValue = (new BN(value)).add(new BN(type.offset));
+  }
+  bnValue.toArrayLike(Buffer, "le", type.byteLength)
     .copy(output, start);
   return offset;
 }

--- a/test/deserialize.test.ts
+++ b/test/deserialize.test.ts
@@ -47,6 +47,7 @@ describe("deserialize", () => {
     {value: "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", type: "uint256", expected: new BN("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", 16)},
     {value: "0000000001000000", type: "number64", expected: 2**32},
     {value: "ffffffffffff0f00", type: "number64", expected: 2**52-1},
+    {value: "ffffffffffffffff", type: "number64", expected: Infinity},
     {value: "04000000deadbeef", type: "bytes8", expected: Buffer.from("deadbeef", "hex")},
     {value: "10000000deadbeefdeadbeefdeadbeefdeadbeef", type: "bytes32", expected: Buffer.from("deadbeefdeadbeefdeadbeefdeadbeef", "hex")},
     {value: "04000000deadbeef", type: "bytes", expected: Buffer.from("deadbeef", "hex")},

--- a/test/serialize.test.ts
+++ b/test/serialize.test.ts
@@ -40,6 +40,7 @@ describe("serialize", () => {
     {value: 2**52-1, type: "uint64", expected: "ffffffffffff0f00"},
     {value: 2**32, type: "number64", expected: "0000000001000000"},
     {value: 2**52-1, type: "number64", expected: "ffffffffffff0f00"},
+    {value: Infinity, type: "number64", expected: "ffffffffffffffff"},
     {value: 1, type: {type: Type.uint, byteLength: 8, offset: 2**32, useNumber: true}, expected: "0100000001000000"},
     {value: 1, type: {type: Type.uint, byteLength: 8, offset: new BN(2**32), useNumber: true}, expected: "0100000001000000"},
     {value: new BN("01", 16), type: "uint64", expected: "0100000000000000"},


### PR DESCRIPTION
Add a new case to uint de/serialization (for handling `FAR_FUTURE_EPOCH`) where:
if type.useNumber && type.byteLength > 6,
then the js number `Infinity` is serialized as "all 1s", and "all 1s" is deserialized to `Infinity`.
These cases already resulted in errors, so this seamlessly expands the functionality without requiring any additional typing machinery.