### PR TITLE
Call pwd appropriately

### DIFF
--- a/scripts/ci-install-spec-test-dependencies.sh
+++ b/scripts/ci-install-spec-test-dependencies.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-WORKDIR=pwd
+WORKDIR=`pwd`
 cd ..
 git clone https://github.com/chainsafe/eth2.0-spec-tests
 git clone https://github.com/chainsafe/lodestar


### PR DESCRIPTION
The ci-install-spec-test-dependencies.sh script has a bug, as mentioned by @mpetrunic [here](https://github.com/ChainSafe/ssz-js/pull/82#issuecomment-489367942)