### PR TITLE
Fix various bugs uncovered running spec tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@babel/preset-env": "^7.3.4",
     "@babel/preset-typescript": "^7.3.3",
     "@babel/register": "^7.0.0",
-    "@chainsafe/eth2.0-spec-test-util": "^0.2.3",
+    "@chainsafe/eth2.0-spec-test-util": "^0.3.0",
     "@types/chai": "^4.1.7",
     "@types/mocha": "^5.2.5",
     "@types/node": "^10.12.17",

--- a/src/deserialize.ts
+++ b/src/deserialize.ts
@@ -60,14 +60,15 @@ function _deserializeArray(data: Buffer, type: ArrayType, start: number, end: nu
     // read off offsets, deserializing values until we hit the first offset index
     for (; currentIndex < firstOffset;) {
       nextIndex = currentIndex + BYTES_PER_LENGTH_PREFIX;
-      nextOffset = start + data.readUIntLE(nextIndex, BYTES_PER_LENGTH_PREFIX);
+      nextOffset = nextIndex === firstOffset
+        ? end
+        : start + data.readUIntLE(nextIndex, BYTES_PER_LENGTH_PREFIX);
       value.push(
         _deserialize(data, type.elementType, currentOffset, nextOffset)
       );
       currentIndex = nextIndex;
       currentOffset = nextOffset;
     }
-    assert(currentOffset === end, "Not all variable bytes consumed");
   } else {
     // all elements fixed-sized
     let index = start;

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -66,7 +66,7 @@ function _serializeArray(value: SerializableArray, type: ArrayType, output: Buff
       // write serialized element to variable section
       nextOffsetIndex = _serialize(v, type.elementType, output, currentOffsetIndex);
       // write offset
-      output.writeUIntLE(currentOffsetIndex, fixedIndex, BYTES_PER_LENGTH_PREFIX)
+      output.writeUIntLE(currentOffsetIndex - start, fixedIndex, BYTES_PER_LENGTH_PREFIX)
       // update offset
       currentOffsetIndex = nextOffsetIndex;
       fixedIndex += BYTES_PER_LENGTH_PREFIX;
@@ -84,7 +84,7 @@ function _serializeArray(value: SerializableArray, type: ArrayType, output: Buff
 function _serializeObject(value: SerializableObject, type: ContainerType, output: Buffer, start: number): number {
   let fixedIndex = start;
   let fixedLength = type.fields
-    .map(([_, fieldType]) => isVariableSizeType(type) ? BYTES_PER_LENGTH_PREFIX : fixedSize(fieldType))
+    .map(([_, fieldType]) => isVariableSizeType(fieldType) ? BYTES_PER_LENGTH_PREFIX : fixedSize(fieldType))
     .reduce((a, b) => a + b, 0)
   let currentOffsetIndex = start + fixedLength;
   let nextOffsetIndex = currentOffsetIndex;
@@ -94,7 +94,7 @@ function _serializeObject(value: SerializableObject, type: ContainerType, output
       // write serialized element to variable section
       nextOffsetIndex = _serialize(value[fieldName], fieldType, output, currentOffsetIndex);
       // write offset
-      output.writeUIntLE(currentOffsetIndex, fixedIndex, BYTES_PER_LENGTH_PREFIX)
+      output.writeUIntLE(currentOffsetIndex - start, fixedIndex, BYTES_PER_LENGTH_PREFIX)
       // update offset
       currentOffsetIndex = nextOffsetIndex;
       fixedIndex += BYTES_PER_LENGTH_PREFIX;

--- a/src/util/hash.ts
+++ b/src/util/hash.ts
@@ -22,7 +22,7 @@ export function pack (input: SerializableValue[], type: FullSSZType): Buffer[] {
   for (const v of input) {
     index = _serialize(v, type, packedBuf, index);
   }
-  const chunkLength = Math.ceil(packedLength / BYTES_PER_CHUNK);
+  const chunkLength = Math.max(Math.ceil(packedLength / BYTES_PER_CHUNK), 1);
   // Chop buffer into chunks
   const chunks = Array.from({ length: chunkLength },
     (_, i) => packedBuf.slice(i * BYTES_PER_CHUNK, i * BYTES_PER_CHUNK + BYTES_PER_CHUNK));
@@ -65,7 +65,7 @@ export function merkleize(chunks: Buffer[]): Buffer {
     }
     chunks.splice(chunks.length / 2, chunks.length / 2);
   }
-  return hash(chunks[0]);
+  return chunks[0];
 }
 
 export function mixInLength(root: Buffer, length: number): Buffer {

--- a/test/spec/core.test.ts
+++ b/test/spec/core.test.ts
@@ -1,31 +1,80 @@
 import {join} from "path";
 import {describeSpecTest} from "@chainsafe/eth2.0-spec-test-util";
 
-import {deserialize, serialize, hashTreeRoot} from "../../src";
+import {deserialize, serialize, hashTreeRoot, signingRoot} from "../../src";
 import * as types from "../../../lodestar/src/types";
 
-import {hydrateType, hydrateValue} from "./util";
+import {hydrateType, hydrateValue, eq} from "./util";
+
+// Serialize
 
 describeSpecTest(
   join(__dirname, "../../../eth2.0-spec-tests/tests/ssz_static/core/ssz_mainnet_random.yaml"),
   serialize,
   ({value, typeName}) => {
     const type = hydrateType((types as any)[typeName]);
-    return [hydrateValue(value, type), type];
+    const v = hydrateValue(value, type)
+    return [v, type];
   },
-  ({serialized}) => serialized.slice(2),
+  ({serialized}) => {
+    return serialized.slice(2)
+  },
   (result) => result.toString('hex'),
-  () => false,
-  (_, index) => index >= 50
 );
 
+// Deserialize
+
 describeSpecTest(
-  join(__dirname, "../../../eth2.0-spec-tests/tests/ssz_static/core/ssz_minimal_zero.yaml"),
-  serialize,
+  join(__dirname, "../../../eth2.0-spec-tests/tests/ssz_static/core/ssz_mainnet_random.yaml"),
+  deserialize,
+  ({serialized, typeName}) => {
+    const type = hydrateType((types as any)[typeName]);
+    return [Buffer.from(serialized.slice(2), 'hex'), type];
+  },
   ({value, typeName}) => {
     const type = hydrateType((types as any)[typeName]);
-    return [hydrateValue(value, type), type];
+    const v = hydrateValue(value, type)
+    return v;
   },
-  ({serialized}) => serialized.slice(2),
+  (result) => result,
+  () => false,
+  () => false,
+  ({typeName}, expect, expected, actual) => {
+    const type = hydrateType((types as any)[typeName]);
+    expect(eq(type, expected, actual)).to.equal(true);
+  },
+);
+
+// hashTreeRoot
+
+describeSpecTest(
+  join(__dirname, "../../../eth2.0-spec-tests/tests/ssz_static/core/ssz_mainnet_random.yaml"),
+  hashTreeRoot,
+  ({value, typeName}) => {
+    const type = hydrateType((types as any)[typeName]);
+    const v = hydrateValue(value, type)
+    return [v, type];
+  },
+  ({root}) => {
+    return root.slice(2)
+  },
   (result) => result.toString('hex'),
+);
+
+// signingRoot
+
+describeSpecTest(
+  join(__dirname, "../../../eth2.0-spec-tests/tests/ssz_static/core/ssz_mainnet_random.yaml"),
+  signingRoot,
+  ({value, typeName}) => {
+    const type = hydrateType((types as any)[typeName]);
+    const v = hydrateValue(value, type)
+    return [v, type];
+  },
+  ({root}) => {
+    return root.slice(2)
+  },
+  (result) => result.toString('hex'),
+  () => false,
+  (testCase) => testCase.signingRoot
 );

--- a/test/spec/util.ts
+++ b/test/spec/util.ts
@@ -48,3 +48,26 @@ function _hydrateValue(obj: any, type: FullSSZType): any {
       return obj;
   }
 }
+
+export function eq(type: any, obj1: any, obj2: any): boolean {
+  const _type = parseType(type);
+  return _eq(_type, obj1, obj2);
+}
+
+function _eq(type: FullSSZType, obj1: any, obj2: any): boolean {
+  switch (type.type) {
+    case Type.uint:
+      return obj1.toString(16) === obj2.toString(16);
+    case Type.bool:
+      return obj1 === obj2;
+    case Type.byteList:
+    case Type.byteVector:
+      return obj1.toString('hex') === obj2.toString('hex');
+    case Type.list:
+    case Type.vector:
+      return obj1.length === obj2.length &&
+        obj1.every((e1: any, i: number) => _eq(type.elementType, e1, obj2[i]));
+    case Type.container:
+      return type.fields.every(([fieldName, fieldType]) => _eq(fieldType, obj1[fieldName], obj2[fieldName]));
+  }
+}


### PR DESCRIPTION
deserialize:
- the final offset isn't read from the fixed area, but is known as the end of the buffer

serialize:
- write offsets with relative rather than absolute index
- check object field type when figuring out the fixed length

hashing
- in pack, ensure there is at least 1 chunk
- don't hash the final chunk when merklizing

These bug fixes let us pass the the 'mainnet' spec tests BUT ci will still fail, because it needs to be run against lodestar with v0.6.1 spec data structures.