### PR TITLE
Exclude spec tests in tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,7 @@
 {
+  "exclude": [
+    "test/spec/**/*.ts"
+  ],
   "compilerOptions": {
     /* Basic Options */
     "target": "esnext",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */


### PR DESCRIPTION
This alleviates out-of-tree typescript errors from lodestar types used in spec tests.