### PR TITLE
signing root should hash truncated type

### DIFF
--- a/src/signingRoot.ts
+++ b/src/signingRoot.ts
@@ -24,5 +24,5 @@ export function signingRoot(value: any, type: AnyContainerType): Buffer {
   assert(_type.type === Type.container);
   const truncatedType = copyType(type) as ContainerType;
   truncatedType.fields.pop();
-  return hashTreeRoot(value, _type);
+  return hashTreeRoot(value, truncatedType);
 }

--- a/src/signingRoot.ts
+++ b/src/signingRoot.ts
@@ -22,7 +22,7 @@ import {
 export function signingRoot(value: any, type: AnyContainerType): Buffer {
   const _type = parseType(type);
   assert(_type.type === Type.container);
-  const truncatedType = copyType(type) as ContainerType;
+  const truncatedType = copyType(_type) as ContainerType;
   truncatedType.fields.pop();
   return hashTreeRoot(value, truncatedType);
 }


### PR DESCRIPTION
hash type without last field instead of full type