### PR TITLE
Set typescript include

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,5 @@
 {
-  "exclude": [
-    "test/spec/**/*.ts"
-  ],
+  "include": ["src"],
   "compilerOptions": {
     /* Basic Options */
     "target": "esnext",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */


### PR DESCRIPTION
Our type declaration files have been broken since we added the `exclude` to our tsconfig.
They have been output to `lib/src` instead of `lib/`. This fixes the issue.