### PR TITLE
Add better error handling in assertValidValue

### DIFF
--- a/src/assertValidValue.ts
+++ b/src/assertValidValue.ts
@@ -12,27 +12,54 @@ import {
 export function assertValidValue(value: any, type: FullSSZType): void {
   switch (type.type) {
     case Type.uint:
-      assert((BN.isBN(value) && value.gten(0)) || (value === Number(value) && value >= 0), 'Invalid uint value')
+      assert(BN.isBN(value) || value === Number(value), 'Invalid uint: not a uint');
+      if (value === Infinity) {
+        break;
+      }
+      assert((new BN(value)).gten(0), 'Invalid uint: value < 0');
+      assert((new BN(value)).lt((new BN(2)).pow(new BN(type.byteLength * 8))), 'Invalid uint: not in range');
       break;
     case Type.bool:
-      assert(value === true || value === false, 'Invalid boolean value');
+      assert(value === true || value === false, 'Invalid boolean: not a boolean');
       break;
     case Type.byteList:
-      assert(value instanceof Uint8Array, 'Invalid byte array value');
+      assert(value instanceof Uint8Array || value instanceof Buffer, 'Invalid byte array: not a Uint8Array/Buffer');
       break;
     case Type.byteVector:
-      assert(value instanceof Uint8Array || value instanceof Buffer, 'Invalid byte array value');
-      assert(value.length === type.length, 'Invalid byte array length');
+      assert(value instanceof Uint8Array || value instanceof Buffer, 'Invalid byte array: not a Uint8Array/Buffer');
+      assert(value.length === type.length, 'Invalid byte array: incorrect length');
       break;
     case Type.list:
-      assert(Array.isArray(value), 'Invalid array value');
+      assert(Array.isArray(value), 'Invalid list: not an Array');
+      value.forEach((element: any, i: number) => {
+        try {
+          assertValidValue(element, type.elementType);
+        } catch (e) {
+          throw new Error(`Invalid list, element ${i}: ${e.message}`);
+        }
+      });
       break;
     case Type.vector:
-      assert(Array.isArray(value), 'Invalid array value');
-      assert(value.length === type.length, 'Invalid array length');
+      assert(Array.isArray(value), 'Invalid vector: not an Array');
+      assert(value.length === type.length, 'Invalid vector: incorrect length');
+      value.forEach((element: any, i: number) => {
+        try {
+          assertValidValue(element, type.elementType);
+        } catch (e) {
+          throw new Error(`Invalid vector, element ${i}: ${e.message}`);
+        }
+      });
       break;
     case Type.container:
-      assert(value === Object(value), 'Invalid object value');
+      assert(value === Object(value), 'Invalid container: not an Object');
+      type.fields.forEach(([fieldName, fieldType]) => {
+        try {
+          assert(value[fieldName] !== undefined, "field does not exist");
+          assertValidValue(value[fieldName], fieldType);
+        } catch (e) {
+          throw new Error(`Invalid container, field ${fieldName}: ${e.message}`);
+        }
+      });
       break;
   }
 }

--- a/src/hashTreeRoot.ts
+++ b/src/hashTreeRoot.ts
@@ -12,6 +12,8 @@ import {
   VectorType,
 } from "./types";
 
+import { assertValidValue } from "./assertValidValue";
+
 import {
   merkleize,
   mixInLength,
@@ -70,5 +72,6 @@ export function _hashTreeRoot(value: SerializableValue, type: FullSSZType): Buff
  */
 export function hashTreeRoot(value: any, type: AnySSZType): Buffer {
   const _type = parseType(type);
+  assertValidValue(value, _type);
   return _hashTreeRoot(value, _type);
 }

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -120,7 +120,6 @@ function _serializeObject(value: SerializableObject, type: ContainerType, output
  * @param start starting index
  */
 export function _serialize(value: SerializableValue, type: FullSSZType, output: Buffer, start: number): number {
-  assertValidValue(value, type);
   switch(type.type) {
     case Type.bool:
       return _serializeBool(value as Bool, output, start);
@@ -142,6 +141,7 @@ export function _serialize(value: SerializableValue, type: FullSSZType, output: 
  */
 export function serialize(value: any, type: AnySSZType): Buffer {
   const _type = parseType(type);
+  assertValidValue(value, _type);
   const buf = Buffer.alloc(size(value, _type));
   _serialize(value, _type, buf, 0);
   return buf;


### PR DESCRIPTION
Slight rework of assertValidValue to recursively validate a value.
This gives us sufficient information to give good error messages that pinpoint issues with complex input data.