### PR TITLE
Comparing infinity - fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "prebuild": "rm -rf lib && rm -rf dist",
     "build": "yarn build-lib && yarn build-web && yarn build-types",
     "build:docs": "typedoc --exclude src/index.ts,src/web.ts --out docs src",
-    "build-lib": "babel src -x .ts -d lib",
+    "build-lib": "babel src -x .ts -d lib --source-maps",
     "build-types": "tsc --incremental --declaration --outDir lib --emitDeclarationOnly",
     "build-web": "webpack --mode production --entry ./lib/web.js --output ./dist/ssz.min.js",
     "check-types": "tsc --incremental --noEmit",

--- a/src/equals.ts
+++ b/src/equals.ts
@@ -59,7 +59,10 @@ export function equals(value1: any, value2: any, type: AnySSZType): boolean {
 function _equals(value1: any, value2: any, type: FullSSZType): boolean {
   switch (type.type) {
     case Type.uint:
-      return (new BN(value1.toString())).eq(new BN(value2.toString()));
+      if(value1 === Infinity || value2 === Infinity) {
+        return value1 === value2;
+      }
+      return (new BN(value1)).eq(new BN(value2));
     case Type.bool:
       return value1 === value2;
     case Type.byteList:

--- a/src/equals.ts
+++ b/src/equals.ts
@@ -59,7 +59,7 @@ export function equals(value1: any, value2: any, type: AnySSZType): boolean {
 function _equals(value1: any, value2: any, type: FullSSZType): boolean {
   switch (type.type) {
     case Type.uint:
-      return (new BN(value1)).eq(new BN(value2));
+      return (new BN(value1.toString())).eq(new BN(value2.toString()));
     case Type.bool:
       return value1 === value2;
     case Type.byteList:

--- a/test/unit/equals.test.ts
+++ b/test/unit/equals.test.ts
@@ -19,6 +19,7 @@ describe("equals", () => {
     {value1: 1, value2: 1, type: "uint8", expected: true},
     {value1: 0, value2: 1, type: "uint8", expected: false},
     {value1: 0, value2: 1, type: "uint8", expected: false},
+    {value1: 0, value2: 1, type: "uint8", expected: false},
     {value1: Infinity, value2: Infinity, type: "uint8", expected: true},
     {value1: new BN(1000), value2: 1000, type: "uint16", expected: true},
     {value1: true, value2: true, type: "bool", expected: true},

--- a/test/unit/equals.test.ts
+++ b/test/unit/equals.test.ts
@@ -18,6 +18,8 @@ describe("equals", () => {
   }[] = [
     {value1: 1, value2: 1, type: "uint8", expected: true},
     {value1: 0, value2: 1, type: "uint8", expected: false},
+    {value1: 0, value2: 1, type: "uint8", expected: false},
+    {value1: Infinity, value2: Infinity, type: "uint8", expected: true},
     {value1: new BN(1000), value2: 1000, type: "uint16", expected: true},
     {value1: true, value2: true, type: "bool", expected: true},
     {value1: false, value2: false, type: "bool", expected: true},


### PR DESCRIPTION
BN constructor fails for number if given infinity as it contains assert to ensure that number is less than safe_int.

Also added sourcemap, to make it easier to detect error in sources