### PR TITLE
replace js-sha256 with wasm implementation

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "lint": "eslint --ext .ts src/ test/",
     "pretest": "yarn check-types",
     "prepublishOnly": "yarn build",
-    "test:spec": "nyc -r lcov -e .ts mocha --timeout 4000 -r ./.babel-register \"test/spec/**/*.test.ts\" && nyc report",
+    "test:spec": "nyc -r lcov -e .ts mocha --timeout 6000 -r ./.babel-register \"test/spec/**/*.test.ts\" && nyc report",
     "test:unit": "nyc -r lcov -e .ts mocha -r ./.babel-register \"test/unit/**/*.test.ts\" && nyc report"
   },
   "homepage": "https://github.com/chainsafe/ssz-js",
@@ -60,6 +60,6 @@
     "@types/bn.js": "^4.11.4",
     "assert": "^1.4.1",
     "bn.js": "^4.11.8",
-    "js-sha256": "^0.9.0"
+    "sha256-rust-wasm": "^1.0.0"
   }
 }

--- a/src/hash.ts
+++ b/src/hash.ts
@@ -1,9 +1,11 @@
 /** @module ssz */
-import { sha256 } from "js-sha256";
+import { Sha256 } from "sha256-rust-wasm";
 
 /**
  * Hash used for hashTreeRoot
  */
 export function hash(...inputs: Buffer[]): Buffer {
-  return Buffer.from(inputs.reduce((acc, i) => acc.update(i), sha256.create()).arrayBuffer());
+  //this will share memory instead of allocating new buffer
+  //https://nodejs.org/api/buffer.html#buffer_buffers_and_typedarray
+  return Buffer.from(inputs.reduce((acc, i) => acc.update(i), Sha256.create()).final().buffer);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2456,10 +2456,6 @@ js-levenshtein@^1.1.3:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/js-levenshtein/-/js-levenshtein-1.1.6.tgz#c6cee58eb3550372df8deb85fad5ce66ce01d59d"
 
-js-sha256@^0.9.0:
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/js-sha256/-/js-sha256-0.9.0.tgz#0b89ac166583e91ef9123644bd3c5334ce9d0966"
-
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
@@ -3617,6 +3613,11 @@ sha.js@^2.4.0, sha.js@^2.4.8:
   dependencies:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
+
+sha256-rust-wasm@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/sha256-rust-wasm/-/sha256-rust-wasm-1.0.0.tgz#f0833e8fe5dd2b81246257ee2faca65a1c2afdae"
+  integrity sha512-0ZKxd8qK1kRLy3cQRV568ss/DAdN3Svz/yMGnW/5UrnxbybbRtX7x4BUi4AtHJ7UFeaJHE1UGNq082L1rimjUQ==
 
 shebang-command@^1.2.0:
   version "1.2.0"


### PR DESCRIPTION
@GregTheGreek benchamrks shows that wasm implementation is quite faster, yet in spec tests it seems like it's slower. Could it be because I didn't set min allocated memory so it has to allocate more memory on large dataset like in spec tests?