### PR TITLE
Add new bit-utils checks to assertValidValue

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "webpack-cli": "^3.2.3"
   },
   "dependencies": {
-    "@chainsafe/bit-utils": "^0.1.2",
+    "@chainsafe/bit-utils": "^0.1.3",
     "@types/bn.js": "^4.11.4",
     "assert": "^1.4.1",
     "bcrypto": "^4.1.0",

--- a/src/assertValidValue.ts
+++ b/src/assertValidValue.ts
@@ -58,11 +58,11 @@ export function _assertValidValue(value: any, type: FullSSZType): void {
       assert(value === true || value === false, 'Invalid boolean: not a boolean');
       break;
     case Type.bitList:
-      assert(value instanceof BitList, 'Invalid BitList: not a BitList');
+      assert(BitList.isBitList(value), 'Invalid BitList: not a BitList');
       assert(value.bitLength <= type.maxLength, 'Invalid BitList: longer than max length');
       break;
     case Type.bitVector:
-      assert(value instanceof BitVector, 'Invalid BitVector: not a BitVector');
+      assert(BitVector.isBitVector(value), 'Invalid BitVector: not a BitVector');
       assert(value.bitLength === type.length, 'Invalid BitVector: incorrect length');
       break;
     case Type.byteList:

--- a/yarn.lock
+++ b/yarn.lock
@@ -614,9 +614,9 @@
     lodash "^4.17.11"
     to-fast-properties "^2.0.0"
 
-"@chainsafe/bit-utils@^0.1.2":
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/@chainsafe/bit-utils/-/bit-utils-0.1.2.tgz#89165bfa24e308f84fa37a39b232bd2a2e533245"
+"@chainsafe/bit-utils@^0.1.3":
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/@chainsafe/bit-utils/-/bit-utils-0.1.3.tgz#d29a69c161526fda8bf0880da3d62a4a7100e169"
 
 "@chainsafe/eth2.0-spec-test-util@^0.3.0":
   version "0.3.0"


### PR DESCRIPTION
The `instanceof` check doesn't work if a bitlist/vector is created from a bit-utils library other than the one imported by ssz.
Eg: if lodestar imports bit-utils and creates a BitList, its not an `instanceof` the BitList from the bit-utils imported in ssz.

Now we use a more sophisticated check built into the bit-utils library.